### PR TITLE
json arrays/objects are not converted to php arrays

### DIFF
--- a/src/Schema.php
+++ b/src/Schema.php
@@ -70,7 +70,7 @@ class Schema extends \yii\db\mysql\Schema
             $columnSchema->type = \yii\db\Schema::TYPE_JSON;
             $columnSchema->phpType = 'array';
             $columnSchema->dbType = \yii\db\Schema::TYPE_JSON;
-            $columnSchema->defaultValue = \json_decode(\trim($columnSchema->defaultValue ??'', "'"));
+            $columnSchema->defaultValue = \json_decode(\trim($columnSchema->defaultValue ??'', "'"), true);
         }
 
         if ($info['default'] === 'current_timestamp()') {

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -70,7 +70,9 @@ class Schema extends \yii\db\mysql\Schema
             $columnSchema->type = \yii\db\Schema::TYPE_JSON;
             $columnSchema->phpType = 'array';
             $columnSchema->dbType = \yii\db\Schema::TYPE_JSON;
-            $columnSchema->defaultValue = \json_decode(\trim($columnSchema->defaultValue ??'', "'"), true);
+            if(isset($columnSchema->defaultValue)){
+                $columnSchema->defaultValue = \json_decode(\trim($columnSchema->defaultValue, "'"), true);
+            }
         }
 
         if ($info['default'] === 'current_timestamp()') {

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -70,6 +70,7 @@ class Schema extends \yii\db\mysql\Schema
             $columnSchema->type = \yii\db\Schema::TYPE_JSON;
             $columnSchema->phpType = 'array';
             $columnSchema->dbType = \yii\db\Schema::TYPE_JSON;
+            $columnSchema->defaultValue = \json_decode(\trim($columnSchema->defaultValue ??'', "'"));
         }
 
         if ($info['default'] === 'current_timestamp()') {

--- a/tests/data/mariadb.sql
+++ b/tests/data/mariadb.sql
@@ -209,6 +209,11 @@ CREATE TABLE `dossier` (
 CREATE TABLE `storage` (
   `id` INT(11) NOT NULL AUTO_INCREMENT,
   `data` JSON NOT NULL CHECK (json_valid(`data`)),
+  `defaultValue1` JSON CHECK (json_valid(`defaultValue1`)),
+  `defaultValue2` JSON DEFAULT '[]' NOT NULL CHECK (json_valid(`defaultValue2`)) ,
+  `defaultValue3` JSON DEFAULT '{}' NOT NULL CHECK (json_valid(`defaultValue3`)),
+  `defaultValue4` JSON DEFAULT '[1,2]' NOT NULL CHECK (json_valid(`defaultValue4`)),
+  `defaultValue5` JSON DEFAULT '{"a":1,"b":2}' NOT NULL CHECK (json_valid(`defaultValue5`)),
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 

--- a/tests/mariadb/ActiveRecordTest.php
+++ b/tests/mariadb/ActiveRecordTest.php
@@ -19,7 +19,16 @@ class ActiveRecordTest extends \yiiunit\framework\db\mysql\ActiveRecordTest
             'last_update_time' => '2018-02-21',
         ];
 
-        $storage = new Storage(['data' => $data]);
+        $defaultStorage = new Storage();
+        $defaultStorage->loadDefaultValues();
+
+        $this->assertSame($defaultStorage->defaultValue1, null, 'NULL values preserved');
+        $this->assertSame($defaultStorage->defaultValue2, [], 'Empty array converted');
+        $this->assertSame($defaultStorage->defaultValue3, [], 'Empty object converted');
+        $this->assertSame($defaultStorage->defaultValue4, [1,2], 'Array with elements converted');
+        $this->assertSame($defaultStorage->defaultValue5, ["a"=>1,"b"=>2], 'Object with properties converted');
+
+        $storage = new Storage(['data'=>$data]);
         $this->assertTrue($storage->save(), 'Storage can be saved');
         $this->assertNotNull($storage->id);
 


### PR DESCRIPTION
If you set the default value of a json column, it's not converted by `ActiveRecord::loadDefaultValues()` method, instead it gets returned as a string wrapped in quotes (`[]` becomes `'[]'`)