### PR TITLE
Remove is null check to match mariadb standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,25 @@ Append the new Schema class to the `schemaMap` property and set the `driverName`
 ]
 ```
 
+## Modify check condition for the json column
+Update the `columnBuilderSchemaClass` property to modify the check-pattern.
+Keep in mind: pattern must contain `json_valid` (see section [JSON Column detection](#json-column-detection) )
+
+```php
+'db' => [
+    'class' => Connection::class,
+    'schemaMap' => [
+        'mysql' => [
+            'class' => SamIT\Yii2\MariaDb\Schema::class,
+            'columnBuilderSchemaClass' => [
+                'class' => SamIT\Yii2\MariaDb\ColumnSchemaBuilder::class,
+                'checkPattern' => '[[{name}]] is null or json_valid([[{name}]])',
+            ],
+        ]
+    ]
+]
+```
+
 # JSON Column detection
 Since MariaDB has no built-in JSON data type we need to do some extra work to detect JSON columns.
 We do this by parsing the SQL obtained when using `SHOW CREATE TABLE`. Since MariaDB supports `CHECK` constraints these are used to ensure a column can only contain valid JSON.

--- a/src/ColumnSchemaBuilder.php
+++ b/src/ColumnSchemaBuilder.php
@@ -18,7 +18,7 @@ class ColumnSchemaBuilder extends \yii\db\mysql\ColumnSchemaBuilder
     {
         parent::__construct($type, $length, $db, $config);
         if ($this->isJson()) {
-            $this->check("[[{name}]] is null or json_valid([[{name}]])");
+            $this->check("json_valid([[{name}]])");
         }
     }
 

--- a/src/ColumnSchemaBuilder.php
+++ b/src/ColumnSchemaBuilder.php
@@ -18,7 +18,7 @@ class ColumnSchemaBuilder extends \yii\db\mysql\ColumnSchemaBuilder
      * @var string pattern that is used for the check-clause
      *             token `{name}` will be replaced with the name of the column
      */
-    public $checkPattern = "json_valid([[{name}]])";
+    public string $checkPattern = "json_valid([[{name}]])";
 
     public function __construct(string $type, $length = null, ?Connection $db = null, array $config = [])
     {

--- a/src/ColumnSchemaBuilder.php
+++ b/src/ColumnSchemaBuilder.php
@@ -14,11 +14,17 @@ use yii\db\Connection;
  */
 class ColumnSchemaBuilder extends \yii\db\mysql\ColumnSchemaBuilder
 {
+    /**
+     * @var string pattern that is used for the check-clause
+     *             token `{name}` will be replaced with the name of the column
+     */
+    public $checkPattern = "json_valid([[{name}]])";
+
     public function __construct(string $type, $length = null, ?Connection $db = null, array $config = [])
     {
         parent::__construct($type, $length, $db, $config);
         if ($this->isJson()) {
-            $this->check("json_valid([[{name}]])");
+            $this->check($this->checkPattern);
         }
     }
 

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -19,7 +19,7 @@ class Schema extends \yii\db\mysql\Schema
     /**
      * @var string|class-string|array column schema builder class or class config
      */
-    public $columnBuilderSchemaClass = ColumnSchemaBuilder::class;
+    public string|array $columnBuilderSchemaClass = ColumnSchemaBuilder::class;
 
     /**
      * @var string[][] Outer array uses the table name as key

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -17,6 +17,11 @@ class Schema extends \yii\db\mysql\Schema
     }
 
     /**
+     * @var string|class-string|array column schema builder class or class config
+     */
+    public $columnBuilderSchemaClass = ColumnSchemaBuilder::class;
+
+    /**
      * @var string[][] Outer array uses the table name as key
      */
     private array $jsonColumns = [];
@@ -98,6 +103,6 @@ class Schema extends \yii\db\mysql\Schema
 
     public function createColumnSchemaBuilder($type, $length = null)
     {
-        return new ColumnSchemaBuilder($type, $length, $this->db);
+        return \Yii::createObject($this->columnBuilderSchemaClass, [$type, $length, $this->db]);
     }
 }

--- a/tests/mariadb/ColumnSchemaBuilderTest.php
+++ b/tests/mariadb/ColumnSchemaBuilderTest.php
@@ -30,7 +30,7 @@ class ColumnSchemaBuilderTest extends TestCase
         $this->assertStringNotContainsString('{name}', $builder->toString('test'));
     }
 
-    public function testOverwritingConfig()
+    public function testOverwritingConfig(): void
     {
         $builder = \Yii::createObject([
             'class' => ColumnSchemaBuilder::class,

--- a/tests/mariadb/ColumnSchemaBuilderTest.php
+++ b/tests/mariadb/ColumnSchemaBuilderTest.php
@@ -29,4 +29,14 @@ class ColumnSchemaBuilderTest extends TestCase
         $this->assertInstanceOf(\SamIT\Yii2\MariaDb\ColumnSchemaBuilder::className(), $builder);
         $this->assertStringNotContainsString('{name}', $builder->toString('test'));
     }
+
+    public function testOverwritingConfig()
+    {
+        $builder = \Yii::createObject([
+            'class' => ColumnSchemaBuilder::class,
+            'checkPattern' => '[[{name}]] is null or json_valid([[{name}]])',
+        ], ['json', null, $this->getConnection()]);
+
+        $this->assertStringContainsString('[[test]] is null or json_valid([[test]])', $builder->toString('test'));
+    }
 }


### PR DESCRIPTION
I noticed, that maria db creates the json_check like this:

```sql
CHECK (json_valid(`data`))
```

and your code adds an check for null like this:

```sql
 CHECK (`data` is null or json_valid(`data`)),
```

I made soime tests, and noticed that this NULL-check is not required, because the json_valid() - check already allows NULL-values.

This Pull Request removes the unnecessary NULL-check, and makes the columns created with your class better matching the standards that mariadb is using.

**UPDATE:**
I modified my code to make the check-conmdition changeable via connection config, to keep the option to choose if you like the old ort the new check chondition.