### PR TITLE
fix(column builder): Add loading of column builder for string column definition

### DIFF
--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -47,6 +47,9 @@ class QueryBuilder extends \yii\db\mysql\QueryBuilder
     public function createTable($table, $columns, $options = null)
     {
         foreach ($columns as $name => &$type) {
+            if ($type === \yii\db\Schema::TYPE_JSON) {
+                $type = $this->db->schema->createColumnSchemaBuilder(\yii\db\Schema::TYPE_JSON);
+            }
             if ($type instanceof ColumnSchemaBuilder && \is_string($name)) {
                 $type = $type->toString($name);
             }

--- a/tests/mariadb/QueryBuilderTest.php
+++ b/tests/mariadb/QueryBuilderTest.php
@@ -62,6 +62,11 @@ class QueryBuilderTest extends TestCase
             'abc' => $columnSchemaBuilder
         ]);
         $this->assertStringContainsString($columnSchemaBuilder->toString('abc'), $sql);
+
+        $sqlFromTypeConstant = $builder->createTable(Storage::tableName(), [
+            'abc' => Schema::TYPE_JSON
+        ]);
+        $this->assertEquals($sql, $sqlFromTypeConstant);
     }
 
     public function testExpressionBuilders(): void


### PR DESCRIPTION
I noticed, that this extension is not used, when I try to run the [JsonTest.php] from yii own tests.

Reson was, that the column builder is not loaded when you create a table using the the `Schema::TYPE_JSON`-string constant.

This pull-request:
1.  fixes this, and loads a ColumnBuilder for this case.
2. Adds a new test to make sure ColumnBuilder is returned when using the Schema-constant (or the String `json`)



[JsonTest.php]:  https://github.com/yiisoft/yii2/blob/74290a353a95fd51a48180a541b5fc757522518a/tests/framework/db/mysql/type/JsonTest.php#L31